### PR TITLE
fix: missing requirement (fastscript)

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -24,7 +24,7 @@ doc_path = docs
 # Optional. Same format as setuptools console_scripts
 console_scripts = deep_animate=deep_animator.cli:deep_animate
 # Optional. Same format as setuptools requirements
-requirements = torch>=1.3.0 torchvision>=0.2.1 tqdm imageio==2.3.0 matplotlib==2.2.2 numpy==1.15.0 pandas==0.23.4 Pillow==5.2.0 scikit-image==0.14.0 scikit-learn==0.19.2 scipy==1.1.0 fire ffmpeg
+requirements = torch>=1.3.0 torchvision>=0.2.1 tqdm imageio==2.3.0 matplotlib==2.2.2 numpy==1.15.0 pandas==0.23.4 Pillow==5.2.0 scikit-image==0.14.0 scikit-learn==0.19.2 scipy==1.1.0 fire ffmpeg fastscript>=1.0.0
 # Anything shown as '%(...)s' is substituted with that setting automatically
 doc_host =  https://%(user)s.github.io
 doc_baseurl = /%(lib_name)s/


### PR DESCRIPTION
Missed dependency (at least for Python 3.7.9)

Referenced at: https://github.com/dpoulopoulos/deep_animator/blob/master/deep_animator/cli.py#L10

Log:
```
→ deep_animate

Traceback (most recent call last):
  File "/home/dim/.pyenv/versions/3.7.9/bin/deep_animate", line 5, in <module>
    from deep_animator.cli import deep_animate
  File "/home/dim/.pyenv/versions/3.7.9/lib/python3.7/site-packages/deep_animator/cli.py", line 10, in <module>
    from fastscript import call_parse, Param
ModuleNotFoundError: No module named 'fastscript'
```
